### PR TITLE
add tests for 721 token ejector

### DIFF
--- a/src/test/Bidder.sol
+++ b/src/test/Bidder.sol
@@ -5,8 +5,6 @@ import {DittoMachine} from "../DittoMachine.sol";
 
 contract Bidder {
 
-    DittoMachine immutable dm;
-    constructor(address dmAddr) {
-        dm = DittoMachine(dmAddr);
-    }
+    constructor() {}
+
 }

--- a/src/test/BidderWithEjector.sol
+++ b/src/test/BidderWithEjector.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.4;
+
+import {DittoMachine, IERC721TokenEjector} from "../DittoMachine.sol";
+
+contract BidderWithEjector is IERC721TokenEjector {
+
+    uint256 public ejections;
+
+    DittoMachine immutable dm;
+    constructor(address dmAddr) {
+        dm = DittoMachine(dmAddr);
+    }
+
+    function onERC721Ejected(
+        address operator,
+        address to,
+        uint256 id,
+        bytes calldata data
+    ) external returns (bytes4) {
+        ++ejections;
+        return this.onERC721Ejected.selector;
+    }
+}
+
+contract BidderWithBadEjector is IERC721TokenEjector {
+
+    uint256 public ejections;
+
+    DittoMachine immutable dm;
+    constructor(address dmAddr) {
+        dm = DittoMachine(dmAddr);
+    }
+
+    function onERC721Ejected(
+        address operator,
+        address to,
+        uint256 id,
+        bytes calldata data
+    ) external returns (bytes4) {
+        revert();
+        ++ejections;
+        return this.onERC721Ejected.selector;
+    }
+}
+
+contract BidderWithGassyEjector is IERC721TokenEjector {
+
+    uint256 public ejections;
+    uint256[] public stored;
+
+    DittoMachine immutable dm;
+    constructor(address dmAddr) {
+        dm = DittoMachine(dmAddr);
+    }
+
+    function onERC721Ejected(
+        address operator,
+        address to,
+        uint256 id,
+        bytes calldata data
+    ) external returns (bytes4) {
+        uint256 gas = gasleft();
+        while (stored.length <= gas) {
+            stored.push(gas**gasleft());
+        }
+        ++ejections;
+        return this.onERC721Ejected.selector;
+    }
+}

--- a/src/test/BidderWithEjector.sol
+++ b/src/test/BidderWithEjector.sol
@@ -7,10 +7,7 @@ contract BidderWithEjector is IERC721TokenEjector {
 
     uint256 public ejections;
 
-    DittoMachine immutable dm;
-    constructor(address dmAddr) {
-        dm = DittoMachine(dmAddr);
-    }
+    constructor() {}
 
     function onERC721Ejected(
         address operator,
@@ -27,10 +24,7 @@ contract BidderWithBadEjector is IERC721TokenEjector {
 
     uint256 public ejections;
 
-    DittoMachine immutable dm;
-    constructor(address dmAddr) {
-        dm = DittoMachine(dmAddr);
-    }
+    constructor() {}
 
     function onERC721Ejected(
         address operator,
@@ -49,10 +43,7 @@ contract BidderWithGassyEjector is IERC721TokenEjector {
     uint256 public ejections;
     uint256[] public stored;
 
-    DittoMachine immutable dm;
-    constructor(address dmAddr) {
-        dm = DittoMachine(dmAddr);
-    }
+    constructor() {}
 
     function onERC721Ejected(
         address operator,

--- a/src/test/DittoMachine.t.sol
+++ b/src/test/DittoMachine.t.sol
@@ -51,10 +51,10 @@ contract ContractTest is DSTest, DittoMachine {
     constructor() {
         dm = new DittoMachine();
 
-        bidder = new Bidder(dmAddr);
-        bidderWithEjector = new BidderWithEjector(dmAddr);
-        bidderWithBadEjector = new BidderWithBadEjector(dmAddr);
-        bidderWithGassyEjector = new BidderWithGassyEjector(dmAddr);
+        bidder = new Bidder();
+        bidderWithEjector = new BidderWithEjector();
+        bidderWithBadEjector = new BidderWithBadEjector();
+        bidderWithGassyEjector = new BidderWithGassyEjector();
     }
 
     function setUp() public {


### PR DESCRIPTION
Add three tests for `ERC721TokenEjector` interface and `forceTransferFrom` function. #13 
1. Test expected accounting in ejection function.
2. Test malicious revert inside ejection function.
3. Test potential for out-of-gas inside ejection function.