### PR TITLE
create floor clone tests

### DIFF
--- a/src/DittoMachine.sol
+++ b/src/DittoMachine.sol
@@ -430,7 +430,7 @@ contract DittoMachine is ERC721, ERC721TokenReceiver {
     /**
      * @notice transfer clone without owner/approval checks.
      * @param from current clone owner.
-     * @param to transfer recepient.
+     * @param to transfer recipient.
      * @param id clone id.
      * @dev if the current clone owner implements ERC721Ejected, we call it.
      *    we will still transfer the clone if that call reverts.

--- a/src/DittoMachine.sol
+++ b/src/DittoMachine.sol
@@ -167,13 +167,6 @@ contract DittoMachine is ERC721, ERC721TokenReceiver {
             _tokenId = FLOOR_ID;
         }
 
-        uint256 floorId = uint256(keccak256(abi.encodePacked(
-            _ERC721Contract,
-            FLOOR_ID,
-            _ERC20Contract,
-            true
-        )));
-
         // calculate cloneId by hashing identifiying information
         uint256 cloneId = uint256(keccak256(abi.encodePacked(
             _ERC721Contract,
@@ -188,10 +181,19 @@ contract DittoMachine is ERC721, ERC721TokenReceiver {
         uint256 subsidy;
 
         if (ownerOf[cloneId] == address(0)) {
+
+            uint256 floorId = uint256(keccak256(abi.encodePacked(
+                _ERC721Contract,
+                FLOOR_ID,
+                _ERC20Contract,
+                true
+            )));
+
             subsidy = _amount * MIN_FEE / DNOM; // with current constants subsidy <= _amount
             value = _amount - subsidy;
 
             if (cloneId != floorId && ownerOf[floorId] != address(0)) {
+                // check price of floor clone for price floor
                 uint256 minAmount = cloneIdToShape[floorId].worth;
                 if (value < minAmount) {
                     revert AmountInvalid();
@@ -215,16 +217,10 @@ contract DittoMachine is ERC721, ERC721TokenReceiver {
                 _amount
             );
             _mint(msg.sender, cloneId);
+
         } else {
 
-            CloneShape memory cloneShape;
-
-            if (cloneIdToShape[cloneId].worth > cloneIdToShape[floorId].worth) {
-                // clone's worth is more than the floor perp or the floor perp does not exist
-                cloneShape = cloneIdToShape[cloneId];
-            } else {
-                cloneShape = cloneIdToShape[floorId];
-            }
+            CloneShape memory cloneShape = cloneIdToShape[cloneId];
 
             uint256 minAmount = _getMinAmount(cloneShape);
             uint256 heat = cloneIdToShape[cloneId].heat;
@@ -325,6 +321,14 @@ contract DittoMachine is ERC721, ERC721TokenReceiver {
      * @dev only use it for a minted clone.
      */
     function _getMinAmount(CloneShape memory cloneShape) internal view returns (uint256) {
+        uint256 floorId = uint256(keccak256(abi.encodePacked(
+            cloneShape.ERC721Contract,
+            FLOOR_ID,
+            cloneShape.ERC20Contract,
+            true
+        )));
+        uint256 floorPrice = cloneIdToShape[floorId].worth;
+
         uint256 timeLeft;
         unchecked {
             if (cloneShape.term > block.timestamp) {
@@ -332,9 +336,9 @@ contract DittoMachine is ERC721, ERC721TokenReceiver {
             }
         }
         uint256 termLength = (BASE_TERM-1) + uint256(cloneShape.heat)**2;
-
-        return cloneShape.worth
-            + (cloneShape.worth * timeLeft / termLength);
+        uint256 clonePrice = cloneShape.worth + (cloneShape.worth * timeLeft / termLength);
+        // return floor price if greater than clone auction price
+        return floorPrice > clonePrice ? floorPrice : clonePrice;
     }
 
     ////////////////////////////////////////////////

--- a/src/DittoMachine.sol
+++ b/src/DittoMachine.sol
@@ -167,6 +167,13 @@ contract DittoMachine is ERC721, ERC721TokenReceiver {
             _tokenId = FLOOR_ID;
         }
 
+        uint256 floorId = uint256(keccak256(abi.encodePacked(
+            _ERC721Contract,
+            FLOOR_ID,
+            _ERC20Contract,
+            true
+        )));
+
         // calculate cloneId by hashing identifiying information
         uint256 cloneId = uint256(keccak256(abi.encodePacked(
             _ERC721Contract,
@@ -183,6 +190,14 @@ contract DittoMachine is ERC721, ERC721TokenReceiver {
         if (ownerOf[cloneId] == address(0)) {
             subsidy = _amount * MIN_FEE / DNOM; // with current constants subsidy <= _amount
             value = _amount - subsidy;
+
+            if (cloneId != floorId && ownerOf[floorId] != address(0)) {
+                uint256 minAmount = cloneIdToShape[floorId].worth;
+                if (value < minAmount) {
+                    revert AmountInvalid();
+                }
+            }
+
             cloneIdToShape[cloneId] = CloneShape(
                 _tokenId,
                 value,
@@ -201,12 +216,6 @@ contract DittoMachine is ERC721, ERC721TokenReceiver {
             );
             _mint(msg.sender, cloneId);
         } else {
-            uint256 floorId = uint256(keccak256(abi.encodePacked(
-                _ERC721Contract,
-                FLOOR_ID,
-                _ERC20Contract,
-                true
-            )));
 
             CloneShape memory cloneShape;
 

--- a/src/test/BidderWithEjector.sol
+++ b/src/test/BidderWithEjector.sol
@@ -10,10 +10,10 @@ contract BidderWithEjector is IERC721TokenEjector {
     constructor() {}
 
     function onERC721Ejected(
-        address operator,
-        address to,
-        uint256 id,
-        bytes calldata data
+        address /*data*/,
+        address /*data*/,
+        uint256 /*data*/,
+        bytes calldata /*data*/
     ) external returns (bytes4) {
         ++ejections;
         return this.onERC721Ejected.selector;
@@ -27,10 +27,10 @@ contract BidderWithBadEjector is IERC721TokenEjector {
     constructor() {}
 
     function onERC721Ejected(
-        address operator,
-        address to,
-        uint256 id,
-        bytes calldata data
+        address /*data*/,
+        address /*data*/,
+        uint256 /*data*/,
+        bytes calldata /*data*/
     ) external returns (bytes4) {
         revert();
         ++ejections;
@@ -46,10 +46,10 @@ contract BidderWithGassyEjector is IERC721TokenEjector {
     constructor() {}
 
     function onERC721Ejected(
-        address operator,
-        address to,
-        uint256 id,
-        bytes calldata data
+        address /*data*/,
+        address /*data*/,
+        uint256 /*data*/,
+        bytes calldata /*data*/
     ) external returns (bytes4) {
         uint256 gas = gasleft();
         while (stored.length <= gas) {

--- a/src/test/DittoMachine.t.sol
+++ b/src/test/DittoMachine.t.sol
@@ -730,4 +730,238 @@ contract ContractTest is DSTest, DittoMachine {
         uint256 cloneWorth = getCloneShape(cloneId).worth;
         assertEq(floorWorth, cloneWorth);
     }
+
+    function testFloorSellUnderlyingForFloor() public {
+        // test selling nft when only floor clone exits
+        address eoaSeller = generateAddress("eoaSeller");
+        cheats.startPrank(eoaSeller);
+        nft.mint(eoaSeller, nftTokenId);
+        uint256 nftId = nftTokenId++;
+        assertEq(nft.ownerOf(nftId), eoaSeller);
+        cheats.stopPrank();
+
+        address eoaBidder = generateAddress("eoaBidder");
+        currency.mint(eoaBidder, MIN_AMOUNT_FOR_NEW_CLONE);
+        cheats.startPrank(eoaBidder);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE);
+
+        // buy a clone using the minimum purchase amount
+        uint256 cloneId1 = dm.duplicate(nftAddr, 0, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, true);
+        CloneShape memory shape = getCloneShape(cloneId1);
+        assertEq(dm.ownerOf(cloneId1), eoaBidder);
+
+        // ensure erc20 balances
+        assertEq(currency.balanceOf(eoaBidder), 0);
+        assertEq(currency.balanceOf(dmAddr), MIN_AMOUNT_FOR_NEW_CLONE);
+
+        uint256 subsidy1 = dm.cloneIdToSubsidy(cloneId1);
+        assertEq(subsidy1, MIN_AMOUNT_FOR_NEW_CLONE * MIN_FEE / DNOM);
+
+        CloneShape memory shape1 = getCloneShape(cloneId1);
+        assertEq(shape1.worth, currency.balanceOf(dmAddr) - subsidy1);
+
+        cheats.stopPrank();
+
+        cheats.warp(block.timestamp + 100);
+        cheats.startPrank(eoaSeller);
+        nft.safeTransferFrom(eoaSeller, dmAddr, nftId, abi.encode(currencyAddr, false));
+        cheats.stopPrank();
+        assertEq(currency.balanceOf(eoaSeller), shape1.worth + subsidy1);
+        assertEq(currency.balanceOf(dmAddr), 0);
+
+        // ensure correct oracle related values
+        assertEq(dm.cloneIdToCumulativePrice(cloneId1), shape.worth * 100);
+        assertEq(dm.cloneIdToTimestampLast(cloneId1), block.timestamp);
+    }
+
+    function testFloorSellUnderlyingForCloneWhileFloorExists() public {
+        // test selling nft when floor clone is worth is same as the nft clone
+        // should sell to clone owner with true passed throughnft.safeTransferFrom
+        address eoaSeller = generateAddress("eoaSeller");
+        cheats.startPrank(eoaSeller);
+        nft.mint(eoaSeller, nftTokenId);
+        uint256 nftId = nftTokenId++;
+        assertEq(nft.ownerOf(nftId), eoaSeller);
+        cheats.stopPrank();
+
+        address eoa1 = generateAddress("eoa1");
+        address eoa2 = generateAddress("eoa2");
+
+        currency.mint(eoa1, MIN_AMOUNT_FOR_NEW_CLONE);
+        currency.mint(eoa2, MIN_AMOUNT_FOR_NEW_CLONE);
+
+        cheats.startPrank(eoa1);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE);
+
+        uint256 floorId = dm.duplicate(nftAddr, 0, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, true);
+        cheats.stopPrank();
+
+        cheats.startPrank(eoa2);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE);
+
+        uint256 cloneId = dm.duplicate(nftAddr, nftId, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, false);
+        cheats.stopPrank();
+
+        uint256 floorWorth = getCloneShape(floorId).worth;
+        uint256 cloneWorth = getCloneShape(cloneId).worth;
+        assertEq(floorWorth, cloneWorth);
+
+        cheats.startPrank(eoaSeller);
+        nft.safeTransferFrom(eoaSeller, dmAddr, nftId, abi.encode(currencyAddr, false));
+        cheats.stopPrank();
+
+        assertEq(nft.ownerOf(nftId), eoa2);
+    }
+
+    function testFloorSellUnderlyingForFloorWhileCloneExists() public {
+        // test selling nft when floor clone is worth is same as the nft clone
+        // should sell to floor owner with true passed throughnft.safeTransferFrom
+        address eoaSeller = generateAddress("eoaSeller");
+        cheats.startPrank(eoaSeller);
+        nft.mint(eoaSeller, nftTokenId);
+        uint256 nftId = nftTokenId++;
+        assertEq(nft.ownerOf(nftId), eoaSeller);
+        cheats.stopPrank();
+
+        address eoa1 = generateAddress("eoa1");
+        address eoa2 = generateAddress("eoa2");
+
+        currency.mint(eoa1, MIN_AMOUNT_FOR_NEW_CLONE);
+        currency.mint(eoa2, MIN_AMOUNT_FOR_NEW_CLONE);
+
+        cheats.startPrank(eoa1);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE);
+
+        uint256 floorId = dm.duplicate(nftAddr, 0, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, true);
+        cheats.stopPrank();
+
+        cheats.startPrank(eoa2);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE);
+
+        uint256 cloneId = dm.duplicate(nftAddr, nftId, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, false);
+        cheats.stopPrank();
+
+        uint256 floorWorth = getCloneShape(floorId).worth;
+        uint256 cloneWorth = getCloneShape(cloneId).worth;
+        assertEq(floorWorth, cloneWorth);
+
+        cheats.startPrank(eoaSeller);
+        nft.safeTransferFrom(eoaSeller, dmAddr, nftId, abi.encode(currencyAddr, true));
+        cheats.stopPrank();
+
+        assertEq(nft.ownerOf(nftId), eoa1);
+    }
+
+    function testFloorSellUnderlyingForFloorWithCheaperClone() public {
+        // test selling nft when floor clone is worth more than nft clone
+        // should sell to floor owner whenever the floor is worth more
+        address eoaSeller = generateAddress("eoaSeller");
+        cheats.startPrank(eoaSeller);
+        nft.mint(eoaSeller, nftTokenId);
+        uint256 nftId = nftTokenId++;
+        assertEq(nft.ownerOf(nftId), eoaSeller);
+        cheats.stopPrank();
+
+        address eoa1 = generateAddress("eoa1");
+        address eoa2 = generateAddress("eoa2");
+        address eoa3 = generateAddress("eoa3");
+
+        currency.mint(eoa1, MIN_AMOUNT_FOR_NEW_CLONE * 2);
+        currency.mint(eoa2, MIN_AMOUNT_FOR_NEW_CLONE);
+        currency.mint(eoa3, MIN_AMOUNT_FOR_NEW_CLONE * 2);
+
+        // woa2 purchases nft clone for cheaper
+        cheats.startPrank(eoa2);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE);
+
+        dm.duplicate(nftAddr, nftId, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, false);
+        cheats.stopPrank();
+
+        // eoa1 purchase floor clone for higher price
+        cheats.startPrank(eoa1);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE * 2);
+
+        dm.duplicate(nftAddr, 0, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE * 2, true);
+        cheats.stopPrank();
+
+        // eoaSeller sells nft specifying floor clone as recipient
+        cheats.startPrank(eoaSeller);
+        nft.safeTransferFrom(eoaSeller, dmAddr, nftId, abi.encode(currencyAddr, true));
+        cheats.stopPrank();
+
+        assertEq(nft.ownerOf(nftId), eoa1);
+        assertEq(currency.balanceOf(eoaSeller), MIN_AMOUNT_FOR_NEW_CLONE * 2);
+
+        cheats.startPrank(eoa3);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE * 2);
+
+        dm.duplicate(nftAddr, 0, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE * 2, true);
+        cheats.stopPrank();
+
+        cheats.startPrank(eoa1);
+        //make sure if sellr sets "floor" to "false" contract will still sell to floor clone if it is worth more
+        nft.safeTransferFrom(eoa1, dmAddr, nftId, abi.encode(currencyAddr, false));
+        cheats.stopPrank();
+
+        assertEq(nft.ownerOf(nftId), eoa3);
+        assertEq(currency.balanceOf(eoa1), MIN_AMOUNT_FOR_NEW_CLONE * 2);
+    }
+
+    function testFloorSellUnderlyingForCloneWithCheaperFloor() public {
+        // test selling nft when floor clone is worth less than nft clone
+        // should sell to clone if "floor" is set to "false" in safeTransferFrom
+        // should sell to floor if "floor" is set to "true" in safeTransferFrom
+        address eoaSeller = generateAddress("eoaSeller");
+        cheats.startPrank(eoaSeller);
+        nft.mint(eoaSeller, nftTokenId);
+        uint256 nftId = nftTokenId++;
+        assertEq(nft.ownerOf(nftId), eoaSeller);
+        cheats.stopPrank();
+
+        address eoa1 = generateAddress("eoa1");
+        address eoa2 = generateAddress("eoa2");
+        address eoa3 = generateAddress("eoa3");
+
+        currency.mint(eoa1, MIN_AMOUNT_FOR_NEW_CLONE);
+        currency.mint(eoa2, MIN_AMOUNT_FOR_NEW_CLONE * 2);
+        currency.mint(eoa3, MIN_AMOUNT_FOR_NEW_CLONE * 2);
+
+        // eoa1 purchases floor clone for cheap
+        cheats.startPrank(eoa1);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE);
+
+        dm.duplicate(nftAddr, 0, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, true);
+        cheats.stopPrank();
+
+        // eoa2 purchases nft clone for higher price
+        cheats.startPrank(eoa2);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE * 2);
+
+        dm.duplicate(nftAddr, nftId, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE * 2, false);
+        cheats.stopPrank();
+
+        // eoaSeller sells nft, specifying floor clone as recipient
+        cheats.startPrank(eoaSeller);
+        nft.safeTransferFrom(eoaSeller, dmAddr, nftId, abi.encode(currencyAddr, true));
+        cheats.stopPrank();
+
+        assertEq(nft.ownerOf(nftId), eoa1);
+        assertEq(currency.balanceOf(eoaSeller), MIN_AMOUNT_FOR_NEW_CLONE);
+
+        // eoa3 purchases another floor clone
+        cheats.startPrank(eoa3);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE);
+
+        dm.duplicate(nftAddr, 0, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, true);
+        cheats.stopPrank();
+
+        // eoa1 sells nft for nft clone
+        cheats.startPrank(eoa1);
+        //make sure if sellr sets "floor" to "false" contract will still sell to floor clone if it is worth more
+        nft.safeTransferFrom(eoa1, dmAddr, nftId, abi.encode(currencyAddr, false));
+        cheats.stopPrank();
+
+        assertEq(nft.ownerOf(nftId), eoa2);
+        assertEq(currency.balanceOf(eoa1), MIN_AMOUNT_FOR_NEW_CLONE * 2);
+    }
 }

--- a/src/test/UnderlyingNFTWithRoyalties.sol
+++ b/src/test/UnderlyingNFTWithRoyalties.sol
@@ -12,7 +12,7 @@ contract UnderlyingNFTWithRoyalties is UnderlyingNFT, IERC2981 {
     }
 
     function royaltyInfo(
-        uint256 _tokenId,
+        uint256 /*_tokenId*/,
         uint256 _salePrice
     ) external view returns (
         address receiver,


### PR DESCRIPTION
Creates two tests:
- check that floor clones will set price for unminted clone IDs
- check that floor clones set price for clones that have already been minted
Fixes errors in calculating minimum clone prices.