### PR TITLE
add erc1155 support

### DIFF
--- a/src/DittoMachine.sol
+++ b/src/DittoMachine.sol
@@ -354,11 +354,6 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver {
         bool floor,
         bool ERC1155Contract
     ) private {
-        uint256 balanceBefore;
-        if (ERC1155Contract) {
-            balanceBefore = ERC1155(ERC721Contract).balanceOf(address(this), id);
-        }
-
         uint256 cloneId = uint256(keccak256(abi.encodePacked(
             ERC721Contract,
             id,
@@ -396,7 +391,7 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver {
         _burn(cloneId);
 
         if (ERC1155Contract) {
-            if (ERC1155(ERC721Contract).balanceOf(address(this), id) != balanceBefore+1) {
+            if (ERC1155(ERC721Contract).balanceOf(address(this), id) > 0) {
                 revert NFTNotReceived();
             }
             ERC1155(ERC721Contract).safeTransferFrom(address(this), owner, id, 1, "");

--- a/src/DittoMachine.sol
+++ b/src/DittoMachine.sol
@@ -71,7 +71,11 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver {
 
         if (!cloneShape.floor) {
             // if clone is not a floor return underlying token uri
-            return ERC721(cloneShape.ERC721Contract).tokenURI(cloneShape.tokenId);
+            try ERC721(cloneShape.ERC721Contract).tokenURI(cloneShape.tokenId) returns (string memory uri) {
+                return uri;
+            } catch {
+                return ERC1155(cloneShape.ERC721Contract).uri(cloneShape.tokenId);
+            }
         } else {
 
             string memory _name = string(abi.encodePacked('Ditto Floor #', Strings.toString(id)));

--- a/src/DittoMachine.sol
+++ b/src/DittoMachine.sol
@@ -391,7 +391,7 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver {
         _burn(cloneId);
 
         if (isERC1155) {
-            if (ERC1155(tokenContract).balanceOf(address(this), id) > 0) {
+            if (ERC1155(tokenContract).balanceOf(address(this), id) < 1) {
                 revert NFTNotReceived();
             }
             ERC1155(tokenContract).safeTransferFrom(address(this), owner, id, 1, "");
@@ -472,9 +472,9 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver {
                 revert AmountInvalid();
             }
         }
-        address[] memory ERC20Contracts = new address[](ids.length);
-        bool[] memory floors = new bool[](ids.length);
-        (ERC20Contracts, floors) = abi.decode(data, (address[], bool[]));
+        // address[] memory ERC20Contracts = new address[](ids.length);
+        // bool[] memory floors = new bool[](ids.length);
+        (address[] memory ERC20Contracts, bool[] memory floors) = abi.decode(data, (address[], bool[]));
 
         for (uint256 i; i < ids.length; i++) {
             onTokenReceived(from, msg.sender /*ERC1155 contract address*/, ids[i], ERC20Contracts[i], floors[i], true);

--- a/src/test/DittoMachine.t.sol
+++ b/src/test/DittoMachine.t.sol
@@ -6,7 +6,7 @@ import "../DittoMachine.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 import {Bidder, DittoMachine} from "./Bidder.sol";
 import {BidderWithEjector, BidderWithBadEjector, BidderWithGassyEjector} from "./BidderWithEjector.sol";
-import {ERC721, IERC2981, UnderlyingNFTWithRoyalties, UnderlyingNFT} from "./UnderlyingNFTWithRoyalties.sol";
+import {ERC721, IERC2981, UnderlyingNFTWithRoyalties, UnderlyingNFT, UnderlyingNFT1155} from "./UnderlyingNFTWithRoyalties.sol";
 
 
 contract Currency is ERC20 {
@@ -35,6 +35,9 @@ contract ContractTest is DSTest, DittoMachine {
     UnderlyingNFT nft;
     address nftAddr;
 
+    UnderlyingNFT1155 nft1155;
+    address nft1155Addr;
+
     UnderlyingNFTWithRoyalties nftWR;
     address nftWRAddr;
 
@@ -42,6 +45,7 @@ contract ContractTest is DSTest, DittoMachine {
     address currencyAddr;
 
     uint256 nftTokenId = 0;
+    uint256 nftTokenId1155 = 0;
 
     Bidder immutable bidder;
     BidderWithEjector immutable bidderWithEjector;
@@ -66,6 +70,9 @@ contract ContractTest is DSTest, DittoMachine {
         nft = new UnderlyingNFT();
         nftAddr = address(nft);
 
+        nft1155 = new UnderlyingNFT1155();
+        nft1155Addr = address(nft1155);
+
         nftWR = new UnderlyingNFTWithRoyalties(generateAddress("royaltyReceiver"));
         nftWRAddr = address(nftWR);
 
@@ -82,6 +89,13 @@ contract ContractTest is DSTest, DittoMachine {
         nft.mint(nftOwner, nftTokenId);
 
         return nftTokenId++;
+    }
+
+    function mintNft1155() internal returns (uint256) {
+        address nftOwner = generateAddress(bytes(Strings.toString(nftTokenId1155)));
+        nft1155.mint(nftOwner, nftTokenId1155, 1);
+
+        return nftTokenId1155++;
     }
 
     function getCloneShape(uint256 cloneId) internal view returns (CloneShape memory) {
@@ -388,6 +402,107 @@ contract ContractTest is DSTest, DittoMachine {
         // ensure correct oracle related values
         assertEq(dm.cloneIdToCumulativePrice(cloneId1), shape.worth * 100);
         assertEq(dm.cloneIdToTimestampLast(cloneId1), block.timestamp);
+    }
+
+    function testSellUnderlying1155() public {
+        address eoaSeller = generateAddress("eoaSeller");
+        cheats.startPrank(eoaSeller);
+        nft1155.mint(eoaSeller, nftTokenId1155, 1);
+        uint256 nftId = nftTokenId1155++;
+        assertEq(nft1155.balanceOf(eoaSeller, nftId), 1);
+        cheats.stopPrank();
+
+        address eoaBidder = generateAddress("eoaBidder");
+        currency.mint(eoaBidder, MIN_AMOUNT_FOR_NEW_CLONE);
+        cheats.startPrank(eoaBidder);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE);
+
+        // buy a clone using the minimum purchase amount
+        uint256 cloneId1 = dm.duplicate(nft1155Addr, nftId, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, false);
+        CloneShape memory shape = getCloneShape(cloneId1);
+        assertEq(dm.ownerOf(cloneId1), eoaBidder);
+
+        // ensure erc20 balances
+        assertEq(currency.balanceOf(eoaBidder), 0);
+        assertEq(currency.balanceOf(dmAddr), MIN_AMOUNT_FOR_NEW_CLONE);
+
+        uint256 subsidy1 = dm.cloneIdToSubsidy(cloneId1);
+        assertEq(subsidy1, MIN_AMOUNT_FOR_NEW_CLONE * MIN_FEE / DNOM);
+
+        CloneShape memory shape1 = getCloneShape(cloneId1);
+        assertEq(shape1.worth, currency.balanceOf(dmAddr) - subsidy1);
+
+        cheats.stopPrank();
+
+        cheats.warp(block.timestamp + 100);
+        cheats.startPrank(eoaSeller);
+        nft1155.safeTransferFrom(eoaSeller, dmAddr, nftId, 1, abi.encode(currencyAddr, false));
+        cheats.stopPrank();
+        assertEq(currency.balanceOf(eoaSeller), shape1.worth + subsidy1);
+        assertEq(currency.balanceOf(dmAddr), 0);
+
+        // ensure correct oracle related values
+        assertEq(dm.cloneIdToCumulativePrice(cloneId1), shape.worth * 100);
+        assertEq(dm.cloneIdToTimestampLast(cloneId1), block.timestamp);
+    }
+
+    function testSellUnderlying1155Batch() public {
+        address eoaSeller = generateAddress("eoaSeller");
+        uint256[] memory nftIds = new uint256[](5);
+        for (uint256 i; i < nftIds.length; i++) {
+            nft1155.mint(eoaSeller, nftTokenId1155, 1);
+            nftIds[i] = nftTokenId1155++;
+            assertEq(nft1155.balanceOf(eoaSeller, nftIds[i]), 1);
+        }
+
+        address eoaBidder = generateAddress("eoaBidder");
+        cheats.startPrank(eoaBidder);
+
+        // buy a clone using the minimum purchase amount
+        uint256[] memory cloneIds = new uint256[](nftIds.length);
+        uint256[] memory amounts = new uint256[](nftIds.length);
+        CloneShape[] memory shapes = new CloneShape[](nftIds.length);
+        for (uint256 j; j < cloneIds.length; j++) {
+            currency.mint(eoaBidder, MIN_AMOUNT_FOR_NEW_CLONE);
+            currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE);
+
+            cloneIds[j] = dm.duplicate(nft1155Addr, nftIds[j], currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, false);
+            shapes[j] = getCloneShape(cloneIds[j]);
+            assertEq(dm.ownerOf(cloneIds[j]), eoaBidder);
+            amounts[j] = 1;
+        }
+
+        // ensure erc20 balances
+        assertEq(currency.balanceOf(eoaBidder), 0);
+        assertEq(currency.balanceOf(dmAddr), MIN_AMOUNT_FOR_NEW_CLONE * cloneIds.length);
+
+        uint256 subsidy1 = dm.cloneIdToSubsidy(cloneIds[0]);
+        assertEq(subsidy1, MIN_AMOUNT_FOR_NEW_CLONE * MIN_FEE / DNOM);
+
+        CloneShape memory shape1 = getCloneShape(cloneIds[0]);
+        assertEq(shape1.worth, MIN_AMOUNT_FOR_NEW_CLONE - subsidy1);
+
+        cheats.stopPrank();
+
+        cheats.warp(block.timestamp + 100);
+        cheats.startPrank(eoaSeller);
+        nft1155.safeBatchTransferFrom(
+            eoaSeller,
+            dmAddr,
+            nftIds,
+            amounts,
+            abi.encode(
+                [currencyAddr, currencyAddr, currencyAddr, currencyAddr, currencyAddr],
+                [false, false, false, false, false]
+            )
+        );
+        cheats.stopPrank();
+        assertEq(currency.balanceOf(eoaSeller), (shape1.worth + subsidy1)*5);
+        assertEq(currency.balanceOf(dmAddr), 0);
+
+        // ensure correct oracle related values
+        assertEq(dm.cloneIdToCumulativePrice(cloneIds[0]), shapes[0].worth * 100);
+        assertEq(dm.cloneIdToTimestampLast(cloneIds[0]), block.timestamp);
     }
 
     function testSellUnderlyingWithRoyalties() public {

--- a/src/test/DittoMachine.t.sol
+++ b/src/test/DittoMachine.t.sol
@@ -504,14 +504,23 @@ contract ContractTest is DSTest, DittoMachine {
 
         cheats.warp(block.timestamp + 100);
         cheats.startPrank(eoaSeller);
+
+        address[] memory currencyAddrArray = new address[](5);
+        for (uint i=0;i<5;i++) {
+            currencyAddrArray[i] = currencyAddr;
+        }
+        bool[] memory floorArray = new bool[](5);
+        for (uint i=0;i<5;i++) {
+            floorArray[i] = false;
+        }
         nft1155.safeBatchTransferFrom(
             eoaSeller,
             dmAddr,
             nftIds,
             amounts,
             abi.encode(
-                [currencyAddr, currencyAddr, currencyAddr, currencyAddr, currencyAddr],
-                [false, false, false, false, false]
+                currencyAddrArray,
+                floorArray
             )
         );
         cheats.stopPrank();

--- a/src/test/DittoMachine.t.sol
+++ b/src/test/DittoMachine.t.sol
@@ -111,6 +111,24 @@ contract ContractTest is DSTest, DittoMachine {
         assertEq(dm.symbol(), "DTO");
     }
 
+    function testTokenUri() public {
+        uint256 nftId721 = mintNft();
+        string memory uri721 = nft.tokenURI(nftId721);
+        currency.mint(address(this), MIN_AMOUNT_FOR_NEW_CLONE);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE);
+        uint256 clone0Id = dm.duplicate(nftAddr, nftId721, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, false);
+        assertEq(uri721, dm.tokenURI(clone0Id));
+    }
+
+    function testTokenUri1155() public {
+        uint256 nftId1155 = mintNft1155();
+        string memory uri1155 = nft1155.uri(nftId1155);
+        currency.mint(address(this), MIN_AMOUNT_FOR_NEW_CLONE);
+        currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE);
+        uint256 clone1Id = dm.duplicate(nft1155Addr, nftId1155, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, false);
+        assertEq(uri1155, dm.tokenURI(clone1Id));
+    }
+
     // DittoMachine should revert when ether is sent to it
     function testSendEther() public {
         assertEq(dmAddr.balance, 0);

--- a/src/test/UnderlyingNFT.sol
+++ b/src/test/UnderlyingNFT.sol
@@ -1,7 +1,9 @@
 pragma solidity ^0.8.4;
 
 import {ERC721} from "@rari-capital/solmate/src/tokens/ERC721.sol";
+import {ERC1155} from "@rari-capital/solmate/src/tokens/ERC1155.sol";
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
 contract UnderlyingNFT is ERC721 {
     constructor() ERC721("Underlying", "UNDER") {}
 
@@ -9,6 +11,17 @@ contract UnderlyingNFT is ERC721 {
         _mint(to, id);
     }
     function tokenURI(uint256 id) public pure override returns (string memory) {
+        return string(abi.encodePacked("id: ", Strings.toString(id)));
+    }
+}
+
+contract UnderlyingNFT1155 is ERC1155 {
+    constructor() {}
+
+    function mint(address to, uint256 id, uint256 amount) external {
+        _mint(to, id, amount, "");
+    }
+    function uri(uint256 id) public pure override returns (string memory) {
         return string(abi.encodePacked("id: ", Strings.toString(id)));
     }
 }

--- a/src/test/UnderlyingNFTWithRoyalties.sol
+++ b/src/test/UnderlyingNFTWithRoyalties.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.8.4;
 
 import {IERC2981, IERC165} from "@openzeppelin/contracts/interfaces/IERC2981.sol";
-import {ERC721, UnderlyingNFT} from "./UnderlyingNFT.sol";
+import {ERC721, UnderlyingNFT, UnderlyingNFT1155} from "./UnderlyingNFT.sol";
 
 contract UnderlyingNFTWithRoyalties is UnderlyingNFT, IERC2981 {
 


### PR DESCRIPTION
Adds support for ERC-1155 semi-fungible tokens. There is no reason a clone cannot represent an 1155 token, the contract just lacked the ability to receive them.

- Add the erc-1155 token receiver functions: `onERC1155Received` and `onERC1155BatchReceived`
- Put token receiving logic into `onTokenReceived` function