### PR TITLE
implement recursive clones

### DIFF
--- a/src/DittoMachine.sol
+++ b/src/DittoMachine.sol
@@ -338,7 +338,11 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver {
                 balanceOf[ownerOf[childId]]++;
             }
             cloneIdToShape[_cloneId] = cloneIdToShape[childId];
+            cloneIdToSubsidy[_cloneId] += cloneIdToSubsidy[childId];
+            
+            delete cloneIdToSubsidy[childId];
             delete cloneIdToShape[childId];
+
             ownerOf[_cloneId] = ownerOf[childId];
             delete getApproved[_cloneId];
             _burn(childId);


### PR DESCRIPTION
Replaces clone burns with `_dissolve`. Instead of burning the clone, we check if a child clone exits, if it does we burn the child clone and transfer the parent clone to the child clone's owner, giving the parent clone the properties of the child clone. If the child clone does not exist we burn the parent clone as normal.