### PR TITLE
Map `cloneId` to it's index in Clone List

### DIFF
--- a/src/DittoMachine.sol
+++ b/src/DittoMachine.sol
@@ -72,6 +72,9 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
     // hash protoId with the index placement to get cloneId
     mapping(uint256 => CloneShape) public cloneIdToShape;
 
+    // maps clone to the index it is placed at in a linked list
+    mapping(uint256 => uint256) public cloneIdToIndex;
+
     constructor() ERC721("Ditto", "DTO") { }
 
     ///////////////////////////////////////////
@@ -258,6 +261,7 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
                 block.timestamp + BASE_TERM
             );
             pushListTail(protoId, index);
+            cloneIdToIndex[cloneId] = index;
             cloneIdToSubsidy[cloneId] += subsidy;
             _setBlockRefund(cloneId, subsidy);
 
@@ -351,8 +355,8 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
      * @param protoId specifies the clone to be burned.
      * @dev will refund funds held in a position, subsidy will remain for sellers in the future.
      */
-    function dissolve(uint256 protoId, uint256 index) external {
-        uint256 cloneId = uint256(keccak256(abi.encodePacked(protoId, index)));
+    function dissolve(uint256 protoId, uint256 cloneId) external {
+        uint256 index = cloneIdToIndex[cloneId];
         if (!(msg.sender == ownerOf[cloneId]
                 || msg.sender == getApproved[cloneId]
                 || isApprovedForAll[ownerOf[cloneId]][msg.sender])) {

--- a/src/DittoMachine.sol
+++ b/src/DittoMachine.sol
@@ -378,6 +378,7 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
         address owner = ownerOf[cloneId];
 
         delete cloneIdToShape[cloneId];
+        delete cloneIdToIndex[cloneId];
 
         _burn(cloneId);
         SafeTransferLib.safeTransfer( // EXTERNAL CALL

--- a/src/test/DittoMachine.t.sol
+++ b/src/test/DittoMachine.t.sol
@@ -226,7 +226,7 @@ contract ContractTest is TestBase {
         uint256 index = 0;
         (uint256 cloneId, uint256 protoId) = dm.duplicate(nftAddr, nftId, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, false, index);
         // eoa1 should be able to dissolve the clone it owns
-        dm.dissolve(protoId, index);
+        dm.dissolve(protoId, cloneId);
         // ensure the clone is burned
         assertEq(dm.ownerOf(cloneId), address(0));
         // ensure correct oracle related values
@@ -247,7 +247,7 @@ contract ContractTest is TestBase {
         vm.startPrank(eoa2);
         // eoa2 should not able to dissolve someeone else's clone
         vm.expectRevert(abi.encodeWithSelector(DittoMachine.NotAuthorized.selector));
-        dm.dissolve(protoId, index);
+        dm.dissolve(protoId, cloneId);
         vm.stopPrank();
 
         vm.prank(eoa1);
@@ -256,7 +256,7 @@ contract ContractTest is TestBase {
         vm.prank(eoa2);
         vm.warp(block.timestamp + 100);
         // eoa2 should be able to dissolve the clone when it's owner has given approval for `cloneId`
-        dm.dissolve(/*cloneId,*/ protoId, index);
+        dm.dissolve(/*cloneId,*/ protoId, cloneId);
         assertEq(dm.ownerOf(cloneId), address(0));
 
         // ensure correct oracle related values
@@ -283,7 +283,7 @@ contract ContractTest is TestBase {
         vm.prank(eoa2);
         vm.warp(block.timestamp + 10);
         // eoa2 should be able to dissolve the clone when it's owner has given approval for all the clones it owns
-        dm.dissolve(/*cloneId,*/ protoId, index);
+        dm.dissolve(/*cloneId,*/ protoId, cloneId);
         // ensure correct oracle related values
         assertEq(dm.protoIdToCumulativePrice(protoId), lastCumulativePrice + (shape.worth * 10));
         assertEq(dm.protoIdToTimestampLast(protoId), block.timestamp);

--- a/src/test/MultidimentionalClone.t.sol
+++ b/src/test/MultidimentionalClone.t.sol
@@ -228,7 +228,7 @@ contract MultidimensionalCloneTest is TestBase {
 
 
         vm.startPrank(eoa1);
-        dm.dissolve(protoId0, index0);
+        dm.dissolve(protoId0, cloneId0);
         vm.stopPrank();
         assertEq(dm.ownerOf(cloneId0), address(0));
         assertEq(dm.protoIdToIndexHead(protoId2), 1);
@@ -241,7 +241,7 @@ contract MultidimensionalCloneTest is TestBase {
 
 
         vm.startPrank(eoa3);
-        dm.dissolve(protoId2, index2);
+        dm.dissolve(protoId2, cloneId2);
         vm.stopPrank();
         assertEq(dm.ownerOf(cloneId2), address(0));
         // this dissolve should not move the index head
@@ -254,7 +254,7 @@ contract MultidimensionalCloneTest is TestBase {
 
 
         vm.startPrank(eoa2);
-        dm.dissolve(protoId1, index1);
+        dm.dissolve(protoId1, cloneId1);
         vm.stopPrank();
         assertEq(dm.ownerOf(cloneId1), address(0));
         assertEq(dm.protoIdToIndexHead(protoId2), 3);
@@ -317,7 +317,7 @@ contract MultidimensionalCloneTest is TestBase {
 
         // dissolve middle clone sibling
         vm.startPrank(eoa2);
-        dm.dissolve(protoId1, index1);
+        dm.dissolve(protoId1, cloneId1);
         vm.stopPrank();
         assertEq(dm.ownerOf(cloneId1), address(0));
         assertEq(dm.protoIdToIndexHead(protoId2), 0);


### PR DESCRIPTION
- Maps the clone ID to it's index in the linked list.
- Reconfigure `dissolve()` to take `protoId` and `cloneId` as args. 
- Remove `index` as arg in `dissolve()`.
- Update tests to reflect changes in `dissolve()`.

This update should make it easier for for the `dissolve()` function to be composable with external contracts.