### PR TITLE
Use uint128 for worth and timestamps

### DIFF
--- a/src/BlockRefund.sol
+++ b/src/BlockRefund.sol
@@ -4,11 +4,11 @@ import {SafeTransferLib, ERC20} from "@rari-capital/solmate/src/utils/SafeTransf
 
 abstract contract BlockRefund {
 
-    mapping(uint256 => mapping(uint256 => uint256)) public blockToCloneToFeeRefund;
+    mapping(uint256 => mapping(uint256 => uint128)) public blockToCloneToFeeRefund;
 
     function _setBlockRefund(
         uint256 cloneId,
-        uint256 fullFee
+        uint128 fullFee
     ) internal {
         // assign new info
         blockToCloneToFeeRefund[block.number][cloneId] = fullFee;
@@ -17,7 +17,7 @@ abstract contract BlockRefund {
 
     function _getBlockRefund(
         uint256 cloneId
-    ) public view returns(uint256) {
+    ) public view returns(uint128) {
         return blockToCloneToFeeRefund[block.number][cloneId];
     }
 

--- a/src/DittoMachine.sol
+++ b/src/DittoMachine.sol
@@ -55,10 +55,10 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
         uint256 tokenId;
         address ERC721Contract;
         address ERC20Contract;
-        uint128 worth;
-        uint128 term;
         uint8 heat;
         bool floor;
+        uint128 worth;
+        uint128 term;
     }
 
     // tracks balance of subsidy for a specific cloneId

--- a/src/DittoMachine.sol
+++ b/src/DittoMachine.sol
@@ -43,26 +43,26 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
 
     // ensure that CloneShape can always be casted to int128.
     // change the type to ensure this?
-    uint256 public constant BASE_TERM = 2**18;
-    uint256 public constant MIN_FEE = 32;
-    uint256 public constant DNOM = 2**16 - 1;
-    uint256 public constant MIN_AMOUNT_FOR_NEW_CLONE = BASE_TERM + (BASE_TERM * MIN_FEE / DNOM);
+    uint128 public constant BASE_TERM = 2**18;
+    uint128 public constant MIN_FEE = 32;
+    uint128 public constant DNOM = 2**16 - 1;
+    uint128 public constant MIN_AMOUNT_FOR_NEW_CLONE = BASE_TERM + (BASE_TERM * MIN_FEE / DNOM);
 
     ////////////// STATE VARIABLES //////////////
 
     // variables essential to calculating auction/price information for each cloneId
     struct CloneShape {
         uint256 tokenId;
-        uint256 worth;
         address ERC721Contract;
         address ERC20Contract;
+        uint128 worth;
+        uint128 term;
         uint8 heat;
         bool floor;
-        uint256 term;
     }
 
     // tracks balance of subsidy for a specific cloneId
-    mapping(uint256 => uint256) public cloneIdToSubsidy;
+    mapping(uint256 => uint128) public cloneIdToSubsidy;
 
     // protoId cumulative price for TWAP
     mapping(uint256 => uint256) public protoIdToCumulativePrice;
@@ -189,7 +189,7 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
         address _ERC721Contract,
         uint256 _tokenId,
         address _ERC20Contract,
-        uint256 _amount,
+        uint128 _amount,
         bool floor,
         uint256 index // index at which to mint the clone
     ) external returns (
@@ -231,12 +231,12 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
             )));
             floorId = uint256(keccak256(abi.encodePacked(floorId, index)));
 
-            uint256 subsidy = (_amount * MIN_FEE / DNOM); // with current constants subsidy <= _amount
-            uint256 value = _amount - subsidy;
+            uint128 subsidy = (_amount * MIN_FEE / DNOM); // with current constants subsidy <= _amount
+            uint128 value = _amount - subsidy;
 
             if (cloneId != floorId && ownerOf[floorId] != address(0)) {
                 // check price of floor clone to get price floor
-                uint256 minAmount = cloneIdToShape[floorId].worth;
+                uint128 minAmount = cloneIdToShape[floorId].worth;
                 if (value < minAmount) {
                     revert AmountInvalid();
                 }
@@ -251,15 +251,15 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
 
             _mint(msg.sender, cloneId);
 
-            cloneIdToShape[cloneId] = CloneShape(
-                _tokenId,
-                value,
-                _ERC721Contract,
-                _ERC20Contract,
-                1,
-                floor,
-                block.timestamp + BASE_TERM
-            );
+            cloneIdToShape[cloneId] = CloneShape({
+                tokenId: _tokenId,
+                ERC721Contract: _ERC721Contract,
+                ERC20Contract: _ERC20Contract,
+                worth: value,
+                term: uint128(block.timestamp) + BASE_TERM,
+                heat: 1,
+                floor: floor
+            });
             pushListTail(protoId, index);
             cloneIdToIndex[cloneId] = index;
             cloneIdToSubsidy[cloneId] += subsidy;
@@ -275,16 +275,16 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
         } else {
 
             CloneShape memory cloneShape = cloneIdToShape[cloneId];
-            uint256 heat = cloneShape.heat;
+            uint128 heat = cloneShape.heat;
 
-            uint256 feeRefund = _getBlockRefund(cloneId); // check if bids have occured within the current block
-            uint256 minAmount = _getMinAmount(cloneShape, feeRefund != 0);
+            uint128 feeRefund = _getBlockRefund(cloneId); // check if bids have occured within the current block
+            uint128 minAmount = _getMinAmount(cloneShape, feeRefund != 0);
             // calculate subsidy and worth values
-            uint256 subsidy = (_amount * (MIN_FEE * ((feeRefund == 0 ? 1 : 0) + heat))) / DNOM;
+            uint128 subsidy = (_amount * (MIN_FEE * ((feeRefund == 0 ? 1 : 0) + heat))) / DNOM;
 
             // scoping to prevent "stack too deep" errors
             {
-                uint256 value = _amount - subsidy; // will be applied to cloneShape.worth
+                uint128 value = _amount - subsidy; // will be applied to cloneShape.worth
                 if (index != protoIdToIndexHead[protoId]) { // check cloneId at prior index
                     // prev <- index
                     uint256 elderId = uint256(keccak256(abi.encodePacked(protoId, protoIdToIndexToPrior[protoId][index])));
@@ -299,19 +299,19 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
                 // reduce heat relative to amount of time elapsed by auction
                 if (feeRefund == 0) { // if call is in same block as another keep the current heat
                     if (cloneShape.term > block.timestamp) {
-                        uint256 termLength = BASE_TERM + TimeCurve.calc(heat);
-                        uint256 elapsed = block.timestamp - (cloneShape.term - termLength); // current time - time when the current term started
+                        uint128 termLength = BASE_TERM + TimeCurve.calc(heat);
+                        uint128 elapsed = uint128(block.timestamp) - (cloneShape.term - termLength); // current time - time when the current term started
                         // add 1 to current heat so heat is not stuck at low value with anything but extreme demand for a clone
-                        uint256 cool = (heat+1) * elapsed / termLength;
-                        heat = (cool > heat) ? 1 : Math.min(heat - cool + 1, type(uint8).max);
+                        uint128 cool = (heat+1) * elapsed / termLength;
+                        heat = (cool > heat) ? 1 : uint128(Math.min(heat - cool + 1, type(uint8).max));
                     } else {
                         heat = 1;
                     }
                 }
                 // calculate new clone term values
-                cloneIdToShape[cloneId].worth = value;
                 cloneIdToShape[cloneId].heat = uint8(heat); // does not inherit heat of floor id
-                cloneIdToShape[cloneId].term = block.timestamp + BASE_TERM + TimeCurve.calc(heat);
+                cloneIdToShape[cloneId].worth = value;
+                cloneIdToShape[cloneId].term = uint128(block.timestamp) + BASE_TERM + TimeCurve.calc(heat);
             }
 
             // paying required funds to this contract
@@ -388,19 +388,19 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
         );
     }
 
-    function getMinAmountForCloneTransfer(uint256 cloneId) external view returns (uint256) {
+    function getMinAmountForCloneTransfer(uint256 cloneId) external view returns (uint128) {
         if(ownerOf[cloneId] == address(0)) {
             return MIN_AMOUNT_FOR_NEW_CLONE;
         }
         CloneShape memory cloneShape = cloneIdToShape[cloneId];
         bool intraBlock = _getBlockRefund(cloneId) != 0;
-        uint256 _minAmount = _getMinAmount(cloneShape, intraBlock);
-        // calculate fee ultiplier with heat, if in active bidding block do not add 1.
-        uint256 minFeeHeat = (MIN_FEE * ((intraBlock ? 0:1) + cloneShape.heat));
+        uint128 _minAmount = _getMinAmount(cloneShape, intraBlock);
+        // calculate fee multiplier with heat, if in active bidding block do not add 1.
+        uint128 minFeeHeat = (MIN_FEE * ((intraBlock ? 0:1) + cloneShape.heat));
         // calculate fee needed from min value. Do not devide my DNOM as to not loose percision.
-        uint256 feePercent = _minAmount * minFeeHeat;
+        uint128 feePercent = _minAmount * minFeeHeat;
         // calculate inverse percentage of fee amount
-        uint256 feePortion = (feePercent * DNOM) / (DNOM - minFeeHeat) / DNOM;
+        uint128 feePortion = (feePercent * DNOM) / (DNOM - minFeeHeat) / DNOM;
         return _minAmount + feePortion;
     }
 
@@ -410,7 +410,7 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
      * @param cloneShape clone for which to compute the minimum amount.
      * @dev only use it for a minted clone.
      */
-    function _getMinAmount(CloneShape memory cloneShape, bool intraBlock) internal view returns (uint256) {
+    function _getMinAmount(CloneShape memory cloneShape, bool intraBlock) internal view returns (uint128) {
         uint256 floorId = uint256(keccak256(abi.encodePacked(
             cloneShape.ERC721Contract,
             FLOOR_ID,
@@ -418,21 +418,21 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
             true
         )));
         floorId = uint256(keccak256(abi.encodePacked(floorId, protoIdToIndexHead[floorId])));
-        uint256 floorPrice = cloneIdToShape[floorId].worth;
+        uint128 floorPrice = cloneIdToShape[floorId].worth;
 
         if (intraBlock) {
             // return clone or floor worth without dutch auction pricing if there has been a bid in the current blcok
             return floorPrice > cloneShape.worth ? floorPrice : cloneShape.worth;
         }
 
-        uint256 timeLeft = 0;
+        uint128 timeLeft = 0;
         unchecked {
             if (cloneShape.term > block.timestamp) {
-                timeLeft = cloneShape.term - block.timestamp;
+                timeLeft = cloneShape.term - uint128(block.timestamp);
             }
         }
-        uint256 termLength = BASE_TERM + TimeCurve.calc(cloneShape.heat);
-        uint256 clonePrice = cloneShape.worth + (cloneShape.worth * timeLeft / termLength);
+        uint128 termLength = BASE_TERM + TimeCurve.calc(cloneShape.heat);
+        uint128 clonePrice = cloneShape.worth + (cloneShape.worth * timeLeft / termLength);
         // return floor price if greater than clone auction price
         return floorPrice > clonePrice ? floorPrice : clonePrice;
     }
@@ -507,8 +507,8 @@ contract DittoMachine is ERC721, ERC721TokenReceiver, ERC1155TokenReceiver, Clon
                 cloneShape.tokenId,
                 cloneShape.worth
             );
-            if (royaltyAmount > 0) {
-                cloneShape.worth -= royaltyAmount;
+            if (royaltyAmount > 0 && royaltyAmount < type(uint128).max) {
+                cloneShape.worth -= uint128(royaltyAmount);
                 SafeTransferLib.safeTransfer(
                     ERC20(ERC20Contract),
                     receiver,

--- a/src/TimeCurve.sol
+++ b/src/TimeCurve.sol
@@ -271,7 +271,7 @@ library TimeCurve {
         revert();
     }
 
-    function calc(uint256 heat) internal pure returns(uint256) {
+    function calc(uint256 heat) internal pure returns(uint128) {
         // 7*log(cbrt(heat))*sqrt(heat)
         int128 h = ABDKMath64x64.fromUInt(heat);        // convert heat
 
@@ -283,7 +283,7 @@ library TimeCurve {
         int128 base   = ABDKMath64x64.mul(log7, hSqrt);  // multiply log by sqrt of heat
         int128 length = ABDKMath64x64.mul(SECONDS_IN_DAY, base);      // multiply base by 1 day
 
-        return ABDKMath64x64.toUInt(length);  // convert from abdk 64.64 to uint256
+        return ABDKMath64x64.toUInt(length);  // convert from abdk 64.64 to uint128
     }
 
 }

--- a/src/test/BlockRefund.t.sol
+++ b/src/test/BlockRefund.t.sol
@@ -43,6 +43,7 @@ contract BlockRefundTest is TestBase {
 
     function testRefundFuzz(uint128 amount0, uint128 amount1) public {
         vm.assume(amount0 >= MIN_AMOUNT_FOR_NEW_CLONE);
+        vm.assume(amount1 < 2**123);
         vm.assume(amount0 < amount1);
 
         // amount1 can be assumed to fit because it is greater tha  amount0
@@ -112,7 +113,7 @@ contract BlockRefundTest is TestBase {
 
     function testRefundSelfFuzz(uint128 amount) public {
         vm.assume(amount >= MIN_AMOUNT_FOR_NEW_CLONE);
-        vm.assume(amount < 2**235); // math will overflow error if amount is too large
+        vm.assume(amount < 2**105); // math will overflow error if amount is too large
 
         uint256 nftId = nft.mint();
 

--- a/src/test/BlockRefund.t.sol
+++ b/src/test/BlockRefund.t.sol
@@ -11,11 +11,7 @@ contract BlockRefundTest is TestBase {
     function testRefund() public {
         uint256 nftId = nft.mint();
 
-        for (uint256 i = 0; i<10; ++i) {
-            console.log(i);
-            // vm.roll(block.number+1);
-            // vm.warp(block.timestamp + BASE_TERM + TimeCurve.calc(i+1));
-
+        for (uint128 i = 0; i<10; ++i) {
             address testEoa = generateAddress(bytes(Strings.toString(i)));
 
             currency.mint(testEoa, MIN_AMOUNT_FOR_NEW_CLONE * (i+1));
@@ -42,15 +38,11 @@ contract BlockRefundTest is TestBase {
             console.log(currency.balanceOf(dmAddr));
             console.log((shape.worth + dm.cloneIdToSubsidy(cloneId)));
             assertEq((shape.worth + dm.cloneIdToSubsidy(cloneId)), currency.balanceOf(dmAddr));
-
-            // console.log(dm.cloneIdToSubsidy(cloneId));
-
         }
     }
 
-    function testRefundFuzz(uint256 amount0, uint256 amount1) public {
+    function testRefundFuzz(uint128 amount0, uint128 amount1) public {
         vm.assume(amount0 >= MIN_AMOUNT_FOR_NEW_CLONE);
-        vm.assume(amount1 < 2**240);
         vm.assume(amount0 < amount1);
 
         // amount1 can be assumed to fit because it is greater tha  amount0
@@ -58,7 +50,6 @@ contract BlockRefundTest is TestBase {
         uint256 nftId = nft.mint();
 
         // eoa0 enters clone position
-        address eoa0 = generateAddress("eoa0");
         currency.mint(eoa0, amount0);
 
         vm.startPrank(eoa0);
@@ -72,7 +63,6 @@ contract BlockRefundTest is TestBase {
 
 
         // eoa1 takes clone position in same block
-        address eoa1 = generateAddress("eoa1");
         currency.mint(eoa1, amount1);
 
         vm.startPrank(eoa1);
@@ -87,25 +77,19 @@ contract BlockRefundTest is TestBase {
         // check eoa0 is full refunded
         assertEq(currency.balanceOf(eoa0), amount0, "eoa0 refund");
         assertEq(currency.balanceOf(dmAddr), amount1, "dm balance");
-
-        // console.log(eoa0);
-        // console.log(eoa1);
     }
 
     function testRefundSelf() public {
         uint256 nftId = nft.mint();
 
-        address eoa0 = generateAddress("eoa0");
         currency.mint(eoa0, MIN_AMOUNT_FOR_NEW_CLONE);
 
         vm.startPrank(eoa0);
         currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE);
         // open initial clone position
         (uint256 cloneId, ) = dm.duplicate(nftAddr, nftId, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, false, 0);
-        uint256 sub1 = dm.cloneIdToSubsidy(cloneId);
-        console.log(sub1);
 
-        uint256 minAmountToBuyClone = MIN_AMOUNT_FOR_NEW_CLONE*2;
+        uint128 minAmountToBuyClone = MIN_AMOUNT_FOR_NEW_CLONE*2;
         currency.mint(eoa0, minAmountToBuyClone);
         currency.approve(dmAddr, minAmountToBuyClone);
 
@@ -114,20 +98,11 @@ contract BlockRefundTest is TestBase {
         console.log(currency.balanceOf(dmAddr));
 
         dm.duplicate(nftAddr, nftId, currencyAddr, minAmountToBuyClone, false, 0);
-        uint256 sub2 = dm.cloneIdToSubsidy(cloneId);
-        console.log(sub2);
+        uint128 sub2 = dm.cloneIdToSubsidy(cloneId);
 
         shape = getCloneShape(cloneId);
-        console.log(shape.worth);
 
         uint256 balance = currency.balanceOf(eoa0);
-        // console.log(MIN_AMOUNT_FOR_NEW_CLONE);
-        // console.log(balance);
-        console.log("balance:");
-        console.log(currency.balanceOf(dmAddr));
-
-        console.log("shape worth + subsidy:");
-        console.log(shape.worth + sub2);
 
         assertEq(balance, MIN_AMOUNT_FOR_NEW_CLONE);
         assertEq(shape.worth + sub2, currency.balanceOf(dmAddr), "worth + sub, dm balance");
@@ -135,13 +110,12 @@ contract BlockRefundTest is TestBase {
         vm.stopPrank();
     }
 
-    function testRefundSelfFuzz(uint256 amount) public {
+    function testRefundSelfFuzz(uint128 amount) public {
         vm.assume(amount >= MIN_AMOUNT_FOR_NEW_CLONE);
         vm.assume(amount < 2**235); // math will overflow error if amount is too large
 
         uint256 nftId = nft.mint();
 
-        address eoa0 = generateAddress("eoa0");
         currency.mint(eoa0, amount);
 
         vm.startPrank(eoa0);
@@ -149,7 +123,7 @@ contract BlockRefundTest is TestBase {
         // open initial clone position
         (uint256 cloneId, ) = dm.duplicate(nftAddr, nftId, currencyAddr, amount, false, 0);
 
-        uint256 minAmountToBuyClone = dm.getMinAmountForCloneTransfer(cloneId);
+        uint128 minAmountToBuyClone = dm.getMinAmountForCloneTransfer(cloneId);
         currency.mint(eoa0, minAmountToBuyClone);
         currency.approve(dmAddr, minAmountToBuyClone);
 

--- a/src/test/DittoMachine.t.sol
+++ b/src/test/DittoMachine.t.sol
@@ -62,7 +62,7 @@ contract ContractTest is TestBase {
         // TODO: test revert when clone has been minted.
     }
 
-    function testFailDuplicateForFloor(uint256 _currAmount) public {
+    function testFailDuplicateForFloor(uint128 _currAmount) public {
         dm.duplicate(nftAddr, FLOOR_ID, currencyAddr, _currAmount, true, 0);
     }
 
@@ -160,8 +160,8 @@ contract ContractTest is TestBase {
 
         assertEq(shape1.term, block.timestamp);
 
-        uint256 minAmountToBuyClone = dm.getMinAmountForCloneTransfer(cloneId1);
-        uint256 minAmountWithoutSubsidy = shape1.worth;
+        uint128 minAmountToBuyClone = dm.getMinAmountForCloneTransfer(cloneId1);
+        uint128 minAmountWithoutSubsidy = shape1.worth;
         assertEq(minAmountToBuyClone, minAmountWithoutSubsidy + (minAmountWithoutSubsidy * (MIN_FEE*2) / DNOM));
 
         currency.mint(eoa2, minAmountToBuyClone);

--- a/src/test/Ejector.t.sol
+++ b/src/test/Ejector.t.sol
@@ -17,7 +17,7 @@ contract EjectorTest is TestBase {
         (uint256 cloneId, /*uint256 protoId*/) = dm.duplicate(nftAddr, nftId, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, false, 0);
         vm.stopPrank();
 
-        uint256 minAmountToBuyClone = dm.getMinAmountForCloneTransfer(cloneId);
+        uint128 minAmountToBuyClone = dm.getMinAmountForCloneTransfer(cloneId);
         currency.mint(eoa1, minAmountToBuyClone);
 
         vm.startPrank(eoa1);
@@ -40,7 +40,7 @@ contract EjectorTest is TestBase {
         (uint256 cloneId, /*uint256 protoId*/) = dm.duplicate(nftAddr, nftId, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, false, 0);
         vm.stopPrank();
 
-        uint256 minAmountToBuyClone = dm.getMinAmountForCloneTransfer(cloneId);
+        uint128 minAmountToBuyClone = dm.getMinAmountForCloneTransfer(cloneId);
         currency.mint(eoa1, minAmountToBuyClone);
 
         vm.startPrank(eoa1);
@@ -63,7 +63,7 @@ contract EjectorTest is TestBase {
         (uint256 cloneId, /*uint256 protoId*/) = dm.duplicate(nftAddr, nftId, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, false, 0);
         vm.stopPrank();
 
-        uint256 minAmountToBuyClone = dm.getMinAmountForCloneTransfer(cloneId);
+        uint128 minAmountToBuyClone = dm.getMinAmountForCloneTransfer(cloneId);
         currency.mint(eoa1, minAmountToBuyClone);
 
         vm.startPrank(eoa1);

--- a/src/test/Floor.t.sol
+++ b/src/test/Floor.t.sol
@@ -30,7 +30,7 @@ contract FloorTest is TestBase {
 
         currency.approve(dmAddr, MIN_AMOUNT_FOR_NEW_CLONE * 2);
 
-        uint256 floorWorth = getCloneShape(floorId).worth;
+        uint128 floorWorth = getCloneShape(floorId).worth;
         vm.expectRevert(abi.encodeWithSelector(DittoMachine.AmountInvalid.selector));
         // expect revert with amount less than floor clone worth
         dm.duplicate(nftAddr, nftId, currencyAddr, floorWorth-1, false, 0);
@@ -75,7 +75,7 @@ contract FloorTest is TestBase {
         (uint256 floorId, /*uint256 protoId*/) = dm.duplicate(nftAddr, FLOOR_ID, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE * 3, true, 0);
         vm.stopPrank();
 
-        uint256 newClonePrice = dm.getMinAmountForCloneTransfer(cloneId);
+        uint128 newClonePrice = dm.getMinAmountForCloneTransfer(cloneId);
 
         currency.mint(eoa1, newClonePrice);
 

--- a/src/test/Heat.t.sol
+++ b/src/test/Heat.t.sol
@@ -30,14 +30,11 @@ contract HeatTest is TestBase {
         assertEq(shape.heat, 1);
         // console.log(dm.cloneIdToSubsidy(cloneId));
 
-        vm.stopPrank();
-
-        for (uint256 i = 1; i < 210; i++) {
-            // after 210 price calculation will overflow error when calculating fees
+        for (uint256 i = 1; i < 83; i++) {
+            // after 83 price calculation will overflow error when calculating fees
 
             vm.roll(block.number+1);
             vm.warp(block.timestamp + i);
-            vm.startPrank(eoa1);
 
             uint128 minAmountToBuyClone = dm.getMinAmountForCloneTransfer(cloneId);
             currency.mint(eoa1, minAmountToBuyClone);
@@ -60,9 +57,8 @@ contract HeatTest is TestBase {
             shape = getCloneShape(cloneId);
             assertEq(shape.heat, 1+i);
             console.log(shape.worth);
-
-            vm.stopPrank();
         }
+        vm.stopPrank();
     }
 
     function testHeatStatic() public {

--- a/src/test/TestBase.sol
+++ b/src/test/TestBase.sol
@@ -41,6 +41,7 @@ contract TestBase is Test, DittoMachine {
     BidderWithGassyEjector immutable bidderWithGassyEjector;
 
     address eoaSeller;
+    address eoa0;
     address eoa1;
     address eoa2;
     address eoa3;
@@ -74,6 +75,7 @@ contract TestBase is Test, DittoMachine {
         currencyAddr = address(currency);
 
         eoaSeller = generateAddress("eoaSeller");
+        eoa0 = generateAddress("eoa0");
         eoa1 = generateAddress("eoa1");
         eoa2 = generateAddress("eoa2");
         eoa3 = generateAddress("eoa3");
@@ -85,10 +87,10 @@ contract TestBase is Test, DittoMachine {
     }
 
     function getCloneShape(uint256 cloneId) internal view returns (CloneShape memory) {
-        (uint256 tokenId, uint256 worth, address ERC721Contract,
-            address ERC20Contract, uint8 heat, bool floor, uint256 term) = dm.cloneIdToShape(cloneId);
+        (uint256 tokenId, address ERC721Contract,
+            address ERC20Contract, uint128 worth, uint128 term, uint8 heat, bool floor) = dm.cloneIdToShape(cloneId);
 
-        CloneShape memory shape = CloneShape(tokenId, worth, ERC721Contract, ERC20Contract, heat, floor, term);
+        CloneShape memory shape = CloneShape(tokenId, ERC721Contract, ERC20Contract, worth, term, heat, floor);
         return shape;
     }
 }

--- a/src/test/TestBase.sol
+++ b/src/test/TestBase.sol
@@ -88,9 +88,9 @@ contract TestBase is Test, DittoMachine {
 
     function getCloneShape(uint256 cloneId) internal view returns (CloneShape memory) {
         (uint256 tokenId, address ERC721Contract,
-            address ERC20Contract, uint128 worth, uint128 term, uint8 heat, bool floor) = dm.cloneIdToShape(cloneId);
+            address ERC20Contract, uint8 heat, bool floor, uint128 worth, uint128 term) = dm.cloneIdToShape(cloneId);
 
-        CloneShape memory shape = CloneShape(tokenId, ERC721Contract, ERC20Contract, worth, term, heat, floor);
+        CloneShape memory shape = CloneShape(tokenId, ERC721Contract, ERC20Contract, heat, floor, worth, term);
         return shape;
     }
 }


### PR DESCRIPTION
Use uint128 for clone's worth and timestamp values. This will be required for oracle as to grow observations array, we will make the slot containing timestamp and cumulativeWorth to be non-zero but we still want to keep cumulativeWorth 0.