### PR TITLE
add check that `protoId` and `cloneId` are related in `dissolve`

### DIFF
--- a/src/DittoMachine.sol
+++ b/src/DittoMachine.sol
@@ -272,6 +272,8 @@ contract DittoMachine is ERC1155D, ERC721TokenReceiver, ERC1155TokenReceiver, Cl
      */
     function dissolve(uint protoId, uint cloneId) external returns (bool) {
         uint index = cloneIdToIndex[cloneId];
+        if (uint(keccak256(abi.encodePacked(protoId, index))) != cloneId) revert();
+        
         address owner = ownerOf[cloneId];
         if (!(msg.sender == owner
                 || isApprovedForAll[owner][msg.sender])) {

--- a/src/test/DittoMachine.t.sol
+++ b/src/test/DittoMachine.t.sol
@@ -261,6 +261,16 @@ contract ContractTest is TestBase {
         (uint cloneId, uint protoId) = dm.duplicate(eoa1, nftAddr, nftId, currencyAddr, MIN_AMOUNT_FOR_NEW_CLONE, false, index);
         vm.warp(block.timestamp+10);
         CloneShape memory shape1 = getCloneShape(cloneId);
+
+        vm.expectRevert(); // revert with invalid cloneId
+        dm.dissolve(protoId, 0);
+
+        vm.expectRevert(); // revert with invalid protoId
+        dm.dissolve(0, cloneId);
+
+        vm.expectRevert(); // revert with unminted cloneId
+        dm.dissolve(protoId, uint(keccak256(abi.encodePacked(protoId, index+1))) );
+
         // eoa1 should be able to dissolve the clone it owns
         dm.dissolve(protoId, cloneId);
         // ensure the clone is burned


### PR DESCRIPTION
- checks that `protoId` and `cloneId` are properly supplied to `dissolve()`
- closes #69 